### PR TITLE
Do not use amd for chess.js

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,3 @@
-patch chess.js export # Blocked on yarn 2 failed install
 bug: board covers screen on changing piece theme
 board fill width/height
 persist training options

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,7 +2,10 @@ module.exports = {
   transpileDependencies: ["vuetify"],
   configureWebpack: {
     devtool: "source-map",
-    target: "electron-renderer"
+    target: "electron-renderer",
+    module: {
+      rules: [{ test: /chess.js/, parser: { amd: false } }]
+    }
   },
   pluginOptions: {
     electronBuilder: {


### PR DESCRIPTION
Fix chess.js not a constructor error by disabling AMD for chess.js.